### PR TITLE
Code line number have dark background when printed

### DIFF
--- a/prettify.css
+++ b/prettify.css
@@ -65,3 +65,12 @@ pre code {
   padding: 0;
   background-color: transparent;
 }
+
+/* Override .linenums when printing to avoid dark background */
+@media print {
+  .prettyprint.linenums {
+    -webkit-box-shadow: none;
+        -moz-box-shadow: none;
+            box-shadow: none; 
+  }
+}


### PR DESCRIPTION
Hi, Thanks for the plugin I'm using it often to preview readme files and write docs.

When printing a page rendered with markdownReader the line numbers have a dark background which I think is due to the box-shadow added at prettify.css:15. Adding the following removes the shadow for print and cleans things up:

```
@media print{
    .prettyprint.linenums {
        -webkit-box-shadow: none;
        -moz-box-shadow:    none;
        box-shadow:         none; 
    }
}
```

Would you consider adding to markdownreader.css or prettify.css?

With box-shadow: ![linenums](https://f.cloud.github.com/assets/600349/2311750/4dc33e3e-a2f4-11e3-80b7-89287bbd0efc.png)
