### PR TITLE
Re-adding <code> formatting that was removed with prettify.

### DIFF
--- a/markdownreader.css
+++ b/markdownreader.css
@@ -192,17 +192,17 @@ pre{
 }
 code {
 	padding: 1px 3px;
-    font-size: .72rem;
-    line-height: .72rem;
-    color: #c25;
-    background-color: #f7f7f9;
-    -webkit-border-radius: 3px;
-    -moz-border-radius: 3px;
-    border-radius: 3px;
+	font-size: .72rem;
+	line-height: .72rem;
+	color: #c25;
+	background-color: #f7f7f9;
+	-webkit-border-radius: 3px;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
 	font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
 	border: 1px solid #e1e2e8;
 }
 pre code {
-  padding: 0;
-  background-color: transparent;
+	padding: 0;
+	background-color: transparent;
 }

--- a/markdownreader.css
+++ b/markdownreader.css
@@ -190,3 +190,19 @@ table tr:nth-child(even){background:#FAFAFA;}
 pre{
     padding:5px 0;
 }
+code {
+	padding: 1px 3px;
+    font-size: .72rem;
+    line-height: .72rem;
+    color: #c25;
+    background-color: #f7f7f9;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+	font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
+	border: 1px solid #e1e2e8;
+}
+pre code {
+  padding: 0;
+  background-color: transparent;
+}


### PR DESCRIPTION
I like the look of highlight.js, but prettify included `<code>` formatting. Added css to bring back inline code highlighting.
