### PR TITLE
Add CSS for better rendering in print media type

### DIFF
--- a/markdownreader.css
+++ b/markdownreader.css
@@ -190,3 +190,17 @@ table tr:nth-child(even){background:#FAFAFA;}
 pre{
     padding:5px 0;
 }
+
+@media only print{
+    #markdown-outline, #markdown-backTop {
+        display: none !important;
+    }
+    .content {
+        left: 0 !important;
+        width: auto !important;
+        margin-left: auto !important;
+        background-color: white !important;
+        border: 0 !important;
+        box-shadow: 0 !important;
+    }
+}


### PR DESCRIPTION
Currently, the rendered Markdown looks fine on screen, but does not
print well: the "back to top" link leaves a white box on the page that
overlays some of the text, and some of the text on the right margin is
cut off.

This commit tweaks the CSS (conditional on a print media type, so that
the on-screen rendering is not changed) to reset some of the properties.
With this change, the output looks much better in print.