### PR TITLE
Fix overlapping code line-height

### DIFF
--- a/markdownreader.css
+++ b/markdownreader.css
@@ -195,7 +195,7 @@ pre{
 code.inline {
 	padding: 1px 3px;
 	font-size: .72rem;
-	line-height: .72rem;
+	line-height: 1.12rem;
 	color: #c25;
 	background-color: #f7f7f9;
 	-webkit-border-radius: 3px;


### PR DESCRIPTION
When you have code in a table cell or some container where it wraps to multiple lines after a short amount of characters, the code overlaps itself and is illegible. This fixes that.

**From this:**

<img width="747" alt="screen shot 2017-06-11 at 7 01 47 am" src="https://user-images.githubusercontent.com/8269046/27010848-dd5107c4-4e73-11e7-9b67-d12a4ac9316d.png">

**To this:**

<img width="747" alt="screen shot 2017-06-11 at 7 01 04 am" src="https://user-images.githubusercontent.com/8269046/27010840-c2e47e48-4e73-11e7-8e5e-6b4531c75357.png">

